### PR TITLE
Ensure frontend shutdown flushes telemetry

### DIFF
--- a/cmd/frontend/main.go
+++ b/cmd/frontend/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Create gRPC server with OpenTelemetry instrumentation (enabled by default)
-	server, err := frontend.NewServer(ctx, cfg, backend)
+	server, otelCleanup, err := frontend.NewServer(ctx, cfg, backend)
 	if err != nil {
 		slog.Error("failed to create gRPC server", "error", err)
 		os.Exit(1)
@@ -92,11 +92,12 @@ func main() {
 
 	slog.Info("shutting down gRPC server...")
 
-	// Give outstanding RPCs a chance to complete
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer shutdownCancel()
+	if otelCleanup != nil {
+		// Flush telemetry with a fresh context so shutdown succeeds even if the main context was cancelled.
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cleanupCancel()
+		otelCleanup(cleanupCtx)
+	}
 
-	// Wait for server to stop
-	<-shutdownCtx.Done()
 	slog.Info("gRPC server stopped")
 }

--- a/internal/frontend/server_test.go
+++ b/internal/frontend/server_test.go
@@ -1,0 +1,36 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rajatgoel/gh-go/internal/config"
+	"github.com/rajatgoel/gh-go/internal/sqlbackend"
+)
+
+func TestNewServerReturnsCleanup(t *testing.T) {
+	cfg := &config.Config{
+		ServiceName: "gh-go-frontend-test",
+		Environment: "test",
+		Port:        0,
+	}
+
+	backend, err := sqlbackend.New(context.Background())
+	if err != nil {
+		t.Fatalf("failed to create backend: %v", err)
+	}
+
+	server, cleanup, err := NewServer(context.Background(), cfg, backend)
+	if err != nil {
+		t.Fatalf("failed to create server: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil cleanup function")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	cleanup(shutdownCtx)
+	server.Stop()
+}

--- a/itest/frontend_test.go
+++ b/itest/frontend_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/test/bufconn"
@@ -39,7 +40,7 @@ func setupTestServer(t *testing.T, backend sqlbackend.Backend) (*client.Client, 
 	}
 
 	// Create server
-	s, err := frontend.NewServer(t.Context(), cfg, backend)
+	s, otelCleanup, err := frontend.NewServer(t.Context(), cfg, backend)
 	require.NoError(t, err)
 
 	// Start server in background
@@ -63,6 +64,9 @@ func setupTestServer(t *testing.T, backend sqlbackend.Backend) (*client.Client, 
 	cleanup := func() {
 		c.Close()
 		s.Stop()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
+		defer cleanupCancel()
+		otelCleanup(cleanupCtx)
 	}
 
 	return c, cleanup


### PR DESCRIPTION
## Summary
- return the OpenTelemetry cleanup handle from frontend.NewServer and adjust SetupOTEL to accept a shutdown context
- invoke the cleanup during frontend shutdown using a fresh timeout context and ensure integration tests flush telemetry
- add a regression test confirming NewServer always provides a cleanup function

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ca67d3e1888327b8508837745161f9