### PR TITLE
Update Go version to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 WORKDIR /src
 COPY . .
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -trimpath -o /bin/frontend ./cmd/frontend

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynoinc/gh-go
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/earthboundkid/versioninfo/v2 v2.24.1


### PR DESCRIPTION
## Summary
- Update the module Go version to the latest stable Go release, 1.26.2.
- Align the Docker builder image with Go 1.26 so CI and image builds use a non-vulnerable standard library.

## Verification
- `just test`