### PR TITLE
ci: use patched Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynoinc/gh-go
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/earthboundkid/versioninfo/v2 v2.24.1

--- a/justfile
+++ b/justfile
@@ -1,7 +1,6 @@
 gen:
         go tool buf generate proto
         find . -name sqlc.yaml | xargs go tool sqlc generate -f
-        go fix -fix=all ./...
         go tool goimports -local github.com/dynoinc/gh-go -w .
         go mod tidy
 


### PR DESCRIPTION
## Summary
- bump the module Go version from 1.26.2 to 1.26.4 so GitHub Actions uses a stdlib with current govulncheck fixes
- remove obsolete no-op `go fix -fix=all` from `just gen`

## Test
- `just test`