### PR TITLE
ci: use Go 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dynoinc/gh-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/earthboundkid/versioninfo/v2 v2.24.1


### PR DESCRIPTION
## Summary
- bump the Go version used by setup-go and local tooling to 1.26.5
- pick up the crypto/tls fix reported by govulncheck

## Test
- just test